### PR TITLE
Add headers for Authelia authentication.

### DIFF
--- a/etc/default/readflow.env
+++ b/etc/default/readflow.env
@@ -4,7 +4,9 @@
 
 # Authentication method
 # - `mock`: Generic user use for testing
-# - `proxy`: Use "X-WEBAUTH-USER" or "X-Auth-Username" HTTP header to extract username
+# - `proxy`: For Basic Authentication Use "X-WEBAUTH-USER" or "X-Auth-Username" HTTP header to extract username
+#            For Authelia "Remote-User" and "Remote-Name" are supported (https://www.authelia.com)
+#            Set 'REACT_APP_AUTHORITY=mock' when bulding UI
 # - `https://...`: Use OpenID Connect provider
 READFLOW_AUTHN="https://login.nunux.org/auth/realms/readflow"
 

--- a/etc/default/readflow.env
+++ b/etc/default/readflow.env
@@ -4,9 +4,8 @@
 
 # Authentication method
 # - `mock`: Generic user use for testing
-# - `proxy`: For Basic Authentication Use "X-WEBAUTH-USER" or "X-Auth-Username" HTTP header to extract username
-#            For Authelia "Remote-User" and "Remote-Name" are supported (https://www.authelia.com)
-#            Set 'REACT_APP_AUTHORITY=mock' when bulding UI
+# - `proxy`: For proxied authentication that use "X-WEBAUTH-USER", "X-Auth-Username", "Remote-User" or "Remote-Name" HTTP header as username
+#            Note: Set 'REACT_APP_AUTHORITY=mock' when bulding UI
 # - `https://...`: Use OpenID Connect provider
 READFLOW_AUTHN="https://login.nunux.org/auth/realms/readflow"
 

--- a/pkg/middleware/proxy-auth.go
+++ b/pkg/middleware/proxy-auth.go
@@ -11,6 +11,8 @@ import (
 var usernameHeaderKeys = []string{
 	"X-WEBAUTH-USER",
 	"X-Auth-Username",
+	"Remote-User",
+	"Remote-Name",
 }
 
 func getUsernameFromHeader(header http.Header) string {

--- a/ui/README.md
+++ b/ui/README.md
@@ -9,8 +9,9 @@ You can configure the webapp build by setting environment variables:
 | Variable | Default | Description |
 |----------|---------|-------------|
 | `REACT_APP_API_ROOT` | `https://api.readflow.app` | API base URL. |
-| `REACT_APP_AUTHORITY` | `https://login.readflow.app/auth/realms/readflow` | OpenID Connect authority provider URL. |
+| `REACT_APP_AUTHORITY` | `https://login.readflow.app/auth/realms/readflow` | OpenID Connect authority provider URL. Set to `mock` for both proxy and mock authentication. |
 | `REACT_APP_CLIENT_ID` | `webapp` | OpenID Connect client ID. |
+| `REACT_APP_REDIR_URL` | `https://about.readflow.app` | Page to redirect unauthenticated clients to. Set to `/login` for selfhosting.
 
 Example:
 

--- a/ui/README.md
+++ b/ui/README.md
@@ -11,7 +11,7 @@ You can configure the webapp build by setting environment variables:
 | `REACT_APP_API_ROOT` | `https://api.readflow.app` | API base URL. |
 | `REACT_APP_AUTHORITY` | `https://login.readflow.app/auth/realms/readflow` | OpenID Connect authority provider URL. Set to `mock` for both proxy and mock authentication. |
 | `REACT_APP_CLIENT_ID` | `webapp` | OpenID Connect client ID. |
-| `REACT_APP_REDIR_URL` | `https://about.readflow.app` | Page to redirect unauthenticated clients to. Set to `/login` for selfhosting.
+| `REACT_APP_REDIRECT_URL` | `https://about.readflow.app` | Page to redirect unauthenticated clients to. Set to `/login` for selfhosting.
 
 Example:
 
@@ -33,4 +33,3 @@ The result is stored into the `./build` directory.
 This directory can be served by any web server.
 
 ---
-

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -8,7 +8,7 @@ export const AUTHORITY = process.env.REACT_APP_AUTHORITY || 'https://login.readf
 export const CLIENT_ID = process.env.REACT_APP_CLIENT_ID || 'webapp'
 
 // Unauthenticated user redirect
-export const REDIR_URL = process.env.REACT_APP_REDIR_URL || 'https://about.readflow.app'
+export const REDIRECT_URL = process.env.REACT_APP_REDIRECT_URL || 'https://about.readflow.app'
 
 // VERSION
 export const VERSION = process.env.REACT_APP_VERSION || 'snapshot'

--- a/ui/src/constants.ts
+++ b/ui/src/constants.ts
@@ -7,5 +7,8 @@ export const AUTHORITY = process.env.REACT_APP_AUTHORITY || 'https://login.readf
 // OIDC client ID
 export const CLIENT_ID = process.env.REACT_APP_CLIENT_ID || 'webapp'
 
+// Unauthenticated user redirect
+export const REDIR_URL = process.env.REACT_APP_REDIR_URL || 'https://about.readflow.app'
+
 // VERSION
 export const VERSION = process.env.REACT_APP_VERSION || 'snapshot'

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -10,6 +10,7 @@ import authService from './auth'
 import configureStore from './configureStore'
 import { getOnlineStatus, isTrustedWebActivity } from './helpers'
 import * as serviceWorker from './serviceWorker'
+import { REDIR_URL } from './constants'
 
 const lastRunKey = 'readflow.lastRun'
 
@@ -31,7 +32,7 @@ const login = async () => {
   if (user === null) {
     if (shouldRedirect()) {
       // No previous usage, then redirect to about page.
-      document.location.replace('https://about.readflow.app')
+      document.location.replace(REDIR_URL)
     } else {
       throw new Error('login forced')
     }

--- a/ui/src/index.tsx
+++ b/ui/src/index.tsx
@@ -10,7 +10,7 @@ import authService from './auth'
 import configureStore from './configureStore'
 import { getOnlineStatus, isTrustedWebActivity } from './helpers'
 import * as serviceWorker from './serviceWorker'
-import { REDIR_URL } from './constants'
+import { REDIRECT_URL } from './constants'
 
 const lastRunKey = 'readflow.lastRun'
 
@@ -32,7 +32,7 @@ const login = async () => {
   if (user === null) {
     if (shouldRedirect()) {
       // No previous usage, then redirect to about page.
-      document.location.replace(REDIR_URL)
+      document.location.replace(REDIRECT_URL)
     } else {
       throw new Error('login forced')
     }


### PR DESCRIPTION
- Adds the ability to use https://www.authelia.com/ for authentication checking `Remote-User` and `Remote-Name` header values.
- Added REDIR_URL to constants.tsx to allow setting the unauthenticated user redirect URL using environment variables.
- Updated README for UI
- Updated readflow.env